### PR TITLE
Feature/add httpcontext parameter for angular

### DIFF
--- a/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFrameworkAngularModel.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/Models/TypeScriptFrameworkAngularModel.cs
@@ -42,5 +42,9 @@ namespace NSwag.CodeGeneration.TypeScript.Models
 
         /// <summary>Gets whether the export keyword should be added to all classes and enums.</summary>
         public bool ExportTypes => _settings.TypeScriptGeneratorSettings.ExportTypes;
+
+        /// <summary>Gets or sets the injection token type (used in the Angular template).</summary>
+        public bool IncludeHttpContextParameter => _settings.Template == TypeScriptTemplate.Angular && 
+                                                   _settings.IncludeHttpContextParameter;
     }
 }

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -39,7 +39,7 @@
 {% for operation in Operations -%}
 
     {% template Client.Method.Documentation %}
-    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false%}, {% endif %}{% endfor %}): Observable<{{ operation.ResultType }}> {
+    {{ operation.MethodAccessModifier }}{{ operation.ActualOperationName }}({% for parameter in operation.Parameters %}{{ parameter.VariableName }}{% if GenerateOptionalParameters and parameter.IsOptional %}?{% endif %}: {{ parameter.Type }}{{ parameter.TypePostfix }}{% if parameter.IsLast == false or IncludeHttpContextParameter == true%}, {% endif %}{% endfor %}{% if IncludeHttpContextParameter%}httpContext?: HttpContext{% endif %}) : Observable<{{ operation.ResultType }}> {
         {% template Client.RequestUrl %}
 
 {%     if operation.HasBody -%}
@@ -62,6 +62,9 @@
 {%     if operation.IsFile and Framework.Angular.UseHttpClient == false -%}
             responseType: ResponseContentType.Blob,
 {%     endif -%}
+{%     if IncludeHttpContextParameter -%}
+            httpContext,
+{%     endif -%}
             headers: new {% if Framework.Angular.UseHttpClient %}HttpHeaders{% else %}Headers{% endif %}({
 {%     for parameter in operation.HeaderParameters -%}
                 "{{ parameter.Name }}": {{ parameter.VariableName }} !== undefined && {{ parameter.VariableName }} !== null ? "" + {{ parameter.VariableName }} : "",
@@ -72,7 +75,7 @@
 {%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
                 "Accept": "{{ operation.Produces }}"
 {%     endif -%}
-            })
+            })      
         };
 
 {%     if UseTransformOptionsMethod -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -75,7 +75,7 @@
 {%     if operation.HasResultType and operation.HasAcceptHeaderParameterParameter == false -%}
                 "Accept": "{{ operation.Produces }}"
 {%     endif -%}
-            })      
+            })
         };
 
 {%     if UseTransformOptionsMethod -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/AngularClient.liquid
@@ -63,7 +63,7 @@
             responseType: ResponseContentType.Blob,
 {%     endif -%}
 {%     if IncludeHttpContextParameter -%}
-            httpContext,
+            context: httpContext,
 {%     endif -%}
             headers: new {% if Framework.Angular.UseHttpClient %}HttpHeaders{% else %}Headers{% endif %}({
 {%     for parameter in operation.HeaderParameters -%}

--- a/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
+++ b/src/NSwag.CodeGeneration.TypeScript/Templates/File.liquid
@@ -31,7 +31,7 @@ import { Observable, {% if UseTransformOptionsMethod %}from as {{ Framework.RxJs
 {%             endif -%}
 import { Injectable, Inject, Optional, {{ Framework.Angular.InjectionTokenType }} } from '@angular/core';
 {%             if Framework.Angular.UseHttpClient -%}
-import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase } from '@angular/common/http';
+import { HttpClient, HttpHeaders, HttpResponse, HttpResponseBase{% if IncludeHttpContextParameter %}, HttpContext{% endif %} } from '@angular/common/http';
 {%             else -%}
 import { Http, Headers, ResponseContentType, Response{% if UseTransformOptionsMethod %}, RequestOptionsArgs{% endif %} } from '@angular/http';
 {%             endif -%}

--- a/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
+++ b/src/NSwag.CodeGeneration.TypeScript/TypeScriptClientGeneratorSettings.cs
@@ -111,6 +111,9 @@ namespace NSwag.CodeGeneration.TypeScript
         /// <summary>Gets or sets the injection token type (applies only for the Angular template).</summary>
         public InjectionTokenType InjectionTokenType { get; set; } = InjectionTokenType.OpaqueToken;
 
+        /// <summary>Gets or sets a value to indicate whether to include a httpContext parameter (applies only for the Angular template).</summary>
+        public bool IncludeHttpContextParameter { get; set; } = false;
+
         internal ITemplate CreateTemplate(object model)
         {
             if (Template == TypeScriptTemplate.Aurelia)

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToTypeScriptClientCommand.cs
@@ -387,6 +387,13 @@ namespace NSwag.Commands.CodeGeneration
             set { Settings.TypeScriptGeneratorSettings.InlineNamedAny = value; }
         }
 
+        [Argument(Name = "IncludeHttpContextParameter", IsRequired = false, Description = "Specifies whether to use the IncludeHttpContextParameter (default: false).")]
+        public bool IncludeHttpContextParameter
+        {
+            get { return Settings.IncludeHttpContextParameter; }
+            set { Settings.IncludeHttpContextParameter = value; }
+        }
+
         public override async Task<object> RunAsync(CommandLineProcessor processor, IConsoleHost host)
         {
             var code = await RunAsync();


### PR DESCRIPTION
HttpContext is now available for angular12. It permits to store and retrieve custom metadata for requests, especially in interceptors.

- Add the httpContext as the last optional parameter in each generated method.